### PR TITLE
Update client_metrics.go

### DIFF
--- a/client_metrics.go
+++ b/client_metrics.go
@@ -135,8 +135,9 @@ func (m *ClientMetrics) EnableClientHandlingTimeHistogram(opts ...HistogramOptio
 			m.clientHandledHistogramOpts,
 			[]string{"grpc_type", "grpc_service", "grpc_method"},
 		)
+		m.clientHandledHistogramEnabled = true
 	}
-	m.clientHandledHistogramEnabled = true
+
 }
 
 // EnableClientStreamReceiveTimeHistogram turns on recording of single message receive time of streaming RPCs.


### PR DESCRIPTION
This is an resolution to an error in concurrent go routine read/write.
The error is encountered when we are trying to initialised a grpc service. One API initialises and immediately starts polling to server.
When other API is being initialised, there is concurrent read at github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/client_reporter.go:43  by API 1
and write at github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/client_metrics.go:104  by API 2

Moving the initialisation inside if statement will fix this issue